### PR TITLE
Ensure FIT-to-TCX handles all test files from python-fitparse correctly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      name: Checkout repository and submodules
+      with:
+        submodules: recursive
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "python-fitparse"]
+	path = python-fitparse
+	url = https://github.com/dtcooper/python-fitparse

--- a/fittotcx/program.py
+++ b/fittotcx/program.py
@@ -38,6 +38,15 @@ except ModuleNotFoundError:
 from . import unitconvert
 
 
+if sys.version_info < (3, 2):
+    from datetime import timedelta as _timedelta, tzinfo as _tzinfo
+    class utc(_tzinfo):
+        utcoffset = dst = classmethod(lambda dt: _timedelta(0))
+        tzname = classmethod(lambda dt: 'UTC')
+else:
+    from datetime import timezone
+    utc = timezone.utc
+
 TCD_NAMESPACE = "http://www.garmin.com/xmlschemas/TrainingCenterDatabase/v2"
 TCD = "{%s}" % TCD_NAMESPACE
 

--- a/fittotcx/program.py
+++ b/fittotcx/program.py
@@ -259,7 +259,7 @@ def add_lap(element, activity, lap, epoch_offset=None):
     # Add track points to lap
     trackelem = create_sub_element(lapelem, "Track")
     for trackpoint in activity.get_messages(name="record"):
-        tts = tsz(trackpoint.get_value("timestamp"), epoch_offset)
+        tts, _ = tsz(trackpoint.get_value("timestamp"), epoch_offset)
         if start_time <= tts:
             if end_time is None or tts <= end_time:
                 trackpointelem = create_sub_element(trackelem, "Trackpoint")
@@ -267,7 +267,9 @@ def add_lap(element, activity, lap, epoch_offset=None):
 
 
 def add_activity(element, activity):
-    session = next(activity.get_messages(name="session"))
+    session = next(activity.get_messages(name="session"), None)
+    if session is None:
+        raise FitParseError("FIT file contains no activity session")
 
     # Sport type
     sport = SPORT_MAP.get(session.get_value("sport"), "Other")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.black]
 line-length = 88
 target-version = ['py37']
+extend-exclude = 'python-fitparse'  # submodule
 
 [tool.coverage.run]
 relative_files = true

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,11 @@
+# This setup.py is just a shim to allow local installation from source
+# ("pip install .") to continue working with setuptools<61.0.0.
+#
+# setuptools(>=61.0.0) adds standalone support for installation from
+# pyproject.toml only, with no setup.py shim needed (see
+# https://drivendata.co/blog/python-packaging-2023)
+
+import setuptools
+
+if __name__ == '__main__':
+    setuptools.setup()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -24,12 +24,24 @@ from __future__ import absolute_import, division, print_function
 
 import fittotcx.program as f2t
 import unittest
-import gzip
+import glob
 import lxml.etree
+
+from fitparse import FitParseError
 
 
 class Simple(unittest.TestCase):
-    def test_convert(self):
+    def test_convert_check_results(self):
         converted = f2t.documenttostring(f2t.convert("tests/test.fit"))
-        result = f2t.documenttostring(lxml.etree.parse(open("tests/test.tcx")))
+        with open("tests/test.tcx") as tcx:
+            result = f2t.documenttostring(lxml.etree.parse(tcx))
         self.assertEqual(converted, result)
+
+    def test_convert_check_success(self):
+        for fn in glob.glob("python-fitparse/tests/files/*.fit"):
+            with self.subTest(fn):
+                try:
+                    f2t.convert(fn)
+                except FitParseError:
+                    # If fitparse can't parse it, it's not our fault
+                    pass

--- a/tests/test.tcx
+++ b/tests/test.tcx
@@ -8,7 +8,6 @@
         <DistanceMeters>1000</DistanceMeters>
         <MaximumSpeed>3.449</MaximumSpeed>
         <Calories>32</Calories>
-        <Intensity>Resting</Intensity>
         <TriggerMethod>Distance</TriggerMethod>
         <Track>
           <Trackpoint>
@@ -5815,7 +5814,6 @@
         <DistanceMeters>1000</DistanceMeters>
         <MaximumSpeed>3.24</MaximumSpeed>
         <Calories>93</Calories>
-        <Intensity>Resting</Intensity>
         <TriggerMethod>Distance</TriggerMethod>
         <Track>
           <Trackpoint>
@@ -13022,7 +13020,6 @@
         <DistanceMeters>1000</DistanceMeters>
         <MaximumSpeed>2.92</MaximumSpeed>
         <Calories>109</Calories>
-        <Intensity>Resting</Intensity>
         <TriggerMethod>Distance</TriggerMethod>
         <Track>
           <Trackpoint>
@@ -21821,7 +21818,6 @@
         <DistanceMeters>1000</DistanceMeters>
         <MaximumSpeed>3.047</MaximumSpeed>
         <Calories>107</Calories>
-        <Intensity>Resting</Intensity>
         <TriggerMethod>Distance</TriggerMethod>
         <Track>
           <Trackpoint>
@@ -28495,7 +28491,6 @@
         <DistanceMeters>58.9</DistanceMeters>
         <MaximumSpeed>2.786</MaximumSpeed>
         <Calories>6</Calories>
-        <Intensity>Resting</Intensity>
         <TriggerMethod>Manual</TriggerMethod>
         <Track>
           <Trackpoint>


### PR DESCRIPTION
This PR adds `dtcooper/python-fitparse` as a submodule so we can test against _all_ of [its test files](https://github.com/dtcooper/python-fitparse/tree/master/tests/files). Many of these were not correctly handled by FIT-to-TCX previously.

Then it fixes the resulting issues:

* Handle optional/missing fields better
* Handle files which only have local/relative timestamps
* Readable error for FIT files which contain no activity session message

Also, attempting to parse more of the test files explores more of the branches, and thus increases coverage.